### PR TITLE
Use new endpoint to get dosing studies

### DIFF
--- a/src/apis/Details.api.ts
+++ b/src/apis/Details.api.ts
@@ -222,18 +222,20 @@ export async function getModelDrugDosing(
     return [];
   }
   let response = await fetch(
-    `${process.env.REACT_APP_API_URL}/model_drug_dosing?model_id=eq.${pdcmModelId}&select=*,treatment(name),response(name)`
+    `${process.env.REACT_APP_API_URL}/dosing_studies?model_id=eq.${pdcmModelId}&select=*`
   );
   if (!response.ok) {
     throw new Error("Network response was not ok");
   }
   return response.json().then((d) => {
     return d.map((item: any) => {
-      const treatment: Treatment = camelCase(item);
       const itemCamelCase: any = camelCase(item);
-      treatment.treamentName = itemCamelCase.treatment.name;
-      treatment.treatmentResponse = itemCamelCase.response.name;
-      return treatment;
+      let treatment: Treatment = {
+        treatmentName: itemCamelCase.treatment,
+        treatmentDose: itemCamelCase.dose,
+        treatmentResponse: itemCamelCase.response
+      };
+      return treatment
     });
   });
 }

--- a/src/components/details/DosingStudyTable.tsx
+++ b/src/components/details/DosingStudyTable.tsx
@@ -6,7 +6,7 @@ export interface IDosingStudyTableProps {
 }
 
 export interface Treatment {
-  treamentName: string;
+  treatmentName: string;
   treatmentDose: string;
   treatmentResponse: string;
 }
@@ -26,7 +26,7 @@ export const DosingStudyTable: FunctionComponent<IDosingStudyTableProps> = ({
       <tbody>
         {treatments.map((treatment: Treatment) => (
           <tr>
-            <td>{treatment.treamentName}</td>
+            <td>{treatment.treatmentName}</td>
             <td>{treatment.treatmentDose}</td>
             <td>{treatment.treatmentResponse}</td>
           </tr>


### PR DESCRIPTION
Call the endpoint /dosing_studies to get dosing studies as the previous call was using model_drug_dosing which is a table that doesn't exist anymore in the database