### PR TITLE
[Website] Internal links should scroll to top

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { StaticArticlePage } from "./pages/StaticArticlePage";
 import RouteChangeTracker from "./components/common/RouteChangeTracker";
 import ReactGA from "react-ga4";
 import { ProviderPage } from "./pages/ProviderPage";
+import ScrollToTop from "./components/common/ScrollToTop";
 
 ReactGA.initialize("G-34S5KH94SX");
 
@@ -51,6 +52,7 @@ const routeComponentMap: any = {
 function App() {
   return (
     <BrowserRouter basename="/">
+      <ScrollToTop />
       {process.env.REACT_APP_ENV === "production" ? (
         <RouteChangeTracker />
       ) : null}

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -1,0 +1,19 @@
+import { useEffect, FunctionComponent } from "react";
+import { withRouter } from "react-router-dom";
+import { History } from "history";
+
+const ScrollToTop: FunctionComponent<{ history: History }> = ({ history }) => {
+  useEffect(() => {
+    const unlisten = history.listen(() => {
+      window.scrollTo(0, 0);
+    });
+
+    return () => {
+      unlisten();
+    };
+  }, [history]);
+
+  return null;
+};
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
## Description
When clicking on a link, the page preserves the scroll location. It needs to go to top

## Issue
Fixes https://github.com/PDCMFinder/pdcm-web-ui/issues/119

## Testing instructions
In home, scroll all the way to the bottom and click "Submit" on the nav bar.

## Requested reviewers
@ficolo 