### PR TITLE
View Data link enabled for mutation data but table is empty 

### DIFF
--- a/src/components/details/MolecularDataTable.tsx
+++ b/src/components/details/MolecularDataTable.tsx
@@ -25,7 +25,7 @@ export interface IMolecularCharacterization {
   dataType: string;
   platformId: string;
   platformName: string;
-  dataAvailability: boolean;
+  dataAvailability: "TRUE" | "FALSE";
   dataSource: string;
 }
 
@@ -78,7 +78,7 @@ export const MolecularDataTable: FunctionComponent<
                 <td>
                   {!restrictedTypes.includes(
                     molecularCharacterization.dataType
-                  ) ? (
+                  ) && molecularCharacterization.dataAvailability === "TRUE" ? (
                     <Button
                       onClick={() =>
                         onSelectMolecularCharacterization(


### PR DESCRIPTION
Show "Request Data" button for unavailable mutation data

Fixes https://github.com/PDCMFinder/pdxfinder/issues/1067

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/25350391/220388045-ce0a5c02-e77b-4816-9d79-dda19d6c02f8.png">
